### PR TITLE
stable option, reject erroneous code

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,25 +10,23 @@ const eval = require('docker-js-eval');
 eval('1 + 1', { memory: '8m' }).then(console.log) // 2
 ```
 
-## options:
+## js-eval options:
 
 - `environment`: `node-cjs|node-esm|module|script`
-  - `node-cjs` (default)
-    Like evaluating a normal Node.js CommonJS module
-  - `node-esm`
-    Coming soon
-  - `module`
-    Evaluates as an ES Module
-  - `script`
-    Evaluates as an ES Script
+  - `node-cjs`: Like evaluating a normal Node.js CommonJS module (default)
+  - `node-esm`: Coming soon
+  - `module`: Evaluates as an ES Module
+  - `script`: Evaluates as an ES Script
 - `timeout`: timeout in ms for this code evaluation
 - `cpus`: docker-run cpus option
 - `memory`: docker-run memory option
 - `net`: docker-run network option, default: 'none'
 - `stable`: disable harmony and experimental node flags, default: false
 
-## run.js accepts those environment variables:
 
-- `JSEVAL_ENV`: environment
-- `JSEVAL_TIMEOUT`: sets the [vm](https://nodejs.org/api/vm.html) Script timeout
-- `JSEVAL_DEPTH`: formatting depth
+
+```js run.js
+const run = require('docker-js-eval/run');
+
+run('1+1', 'node-cjs' /* environment */, 1000 /* timeout (optional) */ ).then(console.log) // 2
+```

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ const eval = require('docker-js-eval');
 eval('1 + 1', { memory: '8m' }).then(console.log) // 2
 ```
 
-## js-eval options:
+## [js-eval](index.js) options:
 
 - `environment`: `node-cjs|node-esm|module|script`
   - `node-cjs`: Like evaluating a normal Node.js CommonJS module (default)
@@ -25,9 +25,10 @@ eval('1 + 1', { memory: '8m' }).then(console.log) // 2
 - `stable`: disable harmony and experimental node flags, default: false
 
 
+### [run.js](run.js) usage:
 
-```js run.js
+```js
 const run = require('docker-js-eval/run');
 
-run('1+1', 'node-cjs' /* environment */, 100 /* timeout (optional) */ ).then(console.log) // 2
+run('1+1', 'node-cjs' /* environment */, 100 /* runTimeout (optional) */ ).then(console.log) // 2
 ```

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ eval('1 + 1', { memory: '8m' }).then(console.log) // 2
   - `node-esm`: Coming soon
   - `module`: Evaluates as an ES Module
   - `script`: Evaluates as an ES Script
-- `timeout`: timeout in ms for this code evaluation
+- `timeout`: timeout in ms for this code evaluation to complete
+- `runTimeout`: [vm](https://nodejs.org/api/vm.html) script execution timeout in ms
 - `cpus`: docker-run cpus option
 - `memory`: docker-run memory option
 - `net`: docker-run network option, default: 'none'
@@ -28,5 +29,5 @@ eval('1 + 1', { memory: '8m' }).then(console.log) // 2
 ```js run.js
 const run = require('docker-js-eval/run');
 
-run('1+1', 'node-cjs' /* environment */, 1000 /* timeout (optional) */ ).then(console.log) // 2
+run('1+1', 'node-cjs' /* environment */, 100 /* timeout (optional) */ ).then(console.log) // 2
 ```

--- a/README.md
+++ b/README.md
@@ -5,21 +5,30 @@ $ docker run --rm -i js-eval <<<'1 + 1'
 ```
 
 ```js
-const run = require('docker-js-eval');
+const eval = require('docker-js-eval');
 
-run('1 + 1', { memory: '8m' }).then(console.log) // 2
+eval('1 + 1', { memory: '8m' }).then(console.log) // 2
 ```
 
-Environments (passed with `JSEVAL_ENV` environment variable):
-- `node-cjs` (default)
-  Like evaluating a normal Node.js CommonJS module
-- `node-esm`
-  Coming soon
-- `module`
-  Evaluates as an ES Module
-- `script`
-  Evaluates as an ES Script
+## options:
 
-Other environment variables:
+- `environment`: `node-cjs|node-esm|module|script`
+  - `node-cjs` (default)
+    Like evaluating a normal Node.js CommonJS module
+  - `node-esm`
+    Coming soon
+  - `module`
+    Evaluates as an ES Module
+  - `script`
+    Evaluates as an ES Script
+- `timeout`: timeout in ms for this code evaluation
+- `cpus`: docker-run cpus option
+- `memory`: docker-run memory option
+- `net`: docker-run network option, default: 'none'
+- `stable`: disable harmony and experimental node flags, default: false
+
+## run.js accepts those environment variables:
+
+- `JSEVAL_ENV`: environment
 - `JSEVAL_TIMEOUT`: sets the [vm](https://nodejs.org/api/vm.html) Script timeout
 - `JSEVAL_DEPTH`: formatting depth

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ module.exports = (code, { environment = 'node-cjs', timeout, runTimeout, cpus, m
     if (timeout) {
       timer = setTimeout(() => {
         cp.exec(`docker kill ${name}`, () => {
-          reject(`(Timeout) ${data}`);
+          reject(new Error(`(Timeout) ${data}`));
         });
       }, timeout);
     }
@@ -50,7 +50,7 @@ module.exports = (code, { environment = 'node-cjs', timeout, runTimeout, cpus, m
 
     proc.on('exit', (status) => {
       clearTimeout(timer);
-      if (status) return reject(data); // command code not 0, an error occured
+      if (status) return reject(new Error(data)); // command code not 0, an error occured
       resolve(data);
     });
   });

--- a/index.js
+++ b/index.js
@@ -5,12 +5,12 @@ const crypto = require('crypto');
 
 const CONTAINER = 'devsnek/js-eval';
 
-module.exports = (code, { environment = 'node-cjs', timeout, cpus, memory, net = 'none', stable } = {}) =>
+module.exports = (code, { environment = 'node-cjs', timeout, runTimeout, cpus, memory, net = 'none', stable } = {}) =>
   new Promise((resolve, reject) => {
     const name = `jseval-${crypto.randomBytes(8).toString('hex')}`;
     const args = ['run', '--rm', '-i', `--name=${name}`, `--net=${net}`, `-eJSEVAL_ENV=${environment}`];
-    if (timeout) {
-      args.push(`-eJSEVAL_TIMEOUT=${timeout}`);
+    if (runTimeout) {
+      args.push(`-eJSEVAL_TIMEOUT=${runTimeout}`);
     }
     if (cpus) {
       args.push(`--cpus=${cpus}`);
@@ -35,7 +35,7 @@ module.exports = (code, { environment = 'node-cjs', timeout, cpus, memory, net =
         cp.exec(`docker kill ${name}`, () => {
           reject(`(Timeout) ${data}`);
         });
-      }, timeout + 200);
+      }, timeout);
     }
 
     let data = '';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docker-js-eval",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Evaluate JS in a Docker container",
   "main": "index.js",
   "repository": {

--- a/run.js
+++ b/run.js
@@ -35,13 +35,12 @@ const createNewContext = () => {
   return createContext(O);
 };
 
-const inspect = (val, opts) => {
+const inspect = (val) => {
   try {
     return util.inspect(val, {
       maxArrayLength: 20,
       breakLength: Infinity,
       colors: false,
-      ...opts,
     });
   } catch {
     return '';
@@ -123,9 +122,7 @@ if (!module.parent) {
     }
     try {
       const result = await run(code, process.env.JSEVAL_ENV || 'node-cjs', +process.env.JSEVAL_TIMEOUT || undefined);
-      process.stdout.write(inspect(result, {
-        depth: process.env.JSEVAL_DEPTH ? +process.env.JSEVAL_DEPTH : undefined,
-      }));
+      process.stdout.write(inspect(result));
     } catch (error) {
       decorateErrorStack(error);
       const [result] = inspect(error).split(/at new (Script|Module)/);

--- a/test.js
+++ b/test.js
@@ -28,13 +28,13 @@ execSync('docker build -t devsnek/js-eval:latest .');
   try {
     await jsEval('1 ++ 1');
   } catch (err) {
-    equal(err, 'ecmabot.js:1\n1 ++ 1\n^\n\nReferenceError: Invalid left-hand side expression in postfix operation');
+    equal(err + '', 'Error: ecmabot.js:1\n1 ++ 1\n^\n\nReferenceError: Invalid left-hand side expression in postfix operation');
   }
   try {
     await jsEval('setTimeout(console.log, 5000, 2); 1;', { timeout: 4000 });
     ok(false);
   } catch (err) {
-    equal(err, '(Timeout) 1');
+    equal(err + '', 'Error: (Timeout) 1'); // only test error message
   }
 
   equal(await jsEval('const x=do {1};x'), '1');
@@ -42,7 +42,7 @@ execSync('docker build -t devsnek/js-eval:latest .');
     const x = await jsEval('const x=do {1};x', { stable: true });
     ok(false);
   } catch (e) {
-    equal(e, 'ecmabot.js:1\nconst x=do {1};x\n        ^^\n\nSyntaxError: Unexpected token do');
+    equal(e + '', 'Error: ecmabot.js:1\nconst x=do {1};x\n        ^^\n\nSyntaxError: Unexpected token do');
   }
 
   equal(execSync('docker ps -f name=jseval --format "{{json .}}"') + '', '');

--- a/test.js
+++ b/test.js
@@ -28,13 +28,21 @@ execSync('docker build -t devsnek/js-eval:latest .');
   try {
     await jsEval('1 ++ 1');
   } catch (err) {
-    equal(err + '', 'ecmabot.js:1\n1 ++ 1\n^\n\nReferenceError: Invalid left-hand side expression in postfix operation');
+    equal(err, 'ecmabot.js:1\n1 ++ 1\n^\n\nReferenceError: Invalid left-hand side expression in postfix operation');
   }
   try {
     await jsEval('setTimeout(console.log, 5000, 2); 1;', { timeout: 4000 });
     ok(false);
   } catch (err) {
-    equal(err + '', 'Error: (Timeout) 1');
+    equal(err, '(Timeout) 1');
+  }
+
+  equal(await jsEval('const x=do {1};x'), '1');
+  try {
+    const x = await jsEval('const x=do {1};x', { stable: true });
+    ok(false);
+  } catch (e) {
+    equal(e, 'ecmabot.js:1\nconst x=do {1};x\n        ^^\n\nSyntaxError: Unexpected token do');
   }
 
   equal(execSync('docker ps -f name=jseval --format "{{json .}}"') + '', '');


### PR DESCRIPTION
couple of suggestions
- a stable option to allow disabling harmony flags (greenjello's idea for jellobot, n> and x> commands)
- a [breaking change](https://github.com/devsnek/docker-js-eval/compare/master...caub:fix-timeout?expand=1#diff-168726dbe96b3ce427e7fedce31bb0bcR53): rejecting when the evaluated code throws, to allow to easily know if the evaled code is an error or not 

(ultimately, I'd like that we just `npm i docker-js-eval` from jellobot, and reuse index.js, hence those suggestions)